### PR TITLE
Make load times great again

### DIFF
--- a/world-edit.sc
+++ b/world-edit.sc
@@ -105,7 +105,7 @@ __config()->{
         'flag' -> {
             'type' -> 'term',
             'suggester' -> _(args) -> (
-                typed = if(args:'flag', args:'flag', typed = '-');
+                typed = if(args:'flag', args:'flag', '-');
                 typed_list = split(typed);
                 checked_list = [];
                 for(typed_list,

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -107,6 +107,11 @@ __config()->{
             'suggester' -> _(args) -> (
                 typed = if(args:'flag', args:'flag', typed = '-');
                 typed_list = split(typed);
+                for(typed_list,
+                    if(global_flags~_ == null && _i != 0,
+                        return([]);
+                    );
+                );
                 filtered_flags = filter(global_flags,!(typed_list~_));
                 map(filtered_flags,typed+_);
             ),

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -107,10 +107,12 @@ __config()->{
             'suggester' -> _(args) -> (
                 typed = if(args:'flag', args:'flag', typed = '-');
                 typed_list = split(typed);
+                checked_list = [];
                 for(typed_list,
-                    if(global_flags~_ == null && _i != 0,
+                    if((global_flags~_ == null || checked_list~_ != null) && _i != 0,
                         return([]);
                     );
+                    put(checked_list,length(checked_list),_);
                 );
                 filtered_flags = filter(global_flags,!(typed_list~_));
                 map(filtered_flags,typed+_);

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -109,7 +109,7 @@ __config()->{
                 typed_list = split(typed);
                 checked_list = [];
                 for(typed_list,
-                    if((global_flags~_ == null || checked_list~_ != null) && _i != 0,
+                    if((global_flags~_ == null || checked_list~_ != null) && (_i != 0 || _ != '-'),
                         return([]);
                     );
                     put(checked_list,length(checked_list),_);

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -106,14 +106,11 @@ __config()->{
             'type' -> 'term',
             'suggester' -> _(args) -> (
                 typed = if(args:'flag', args:'flag', typed = '-');
-                if(typed~'^-' == null, return());
-                ret = [];
-                for(global_flags_list,
-                    if(length(_) == length(typed)+1 && _~typed != null, ret += _)
-                );
-                ret
+                if(typed == '-', return(map(global_flags,'-'+_)));
+                typed_list = split(typed);
+                filtered_flags = filter(global_flags,!(typed_list~_));
+                map(filtered_flags,typed+_);
             ),
-            //'options' -> global_flags_list
         },
         'amount'->{'type'->'int'},
         'magnitude'->{'type'->'float','suggest'->[1,2,0.5]},
@@ -470,7 +467,7 @@ _set_or_give_wand(wand) -> (
     )
 );
 
-global_flags = 'waehubp';
+global_flags = ['w','a','e','h','u','b','p'];
 
 //FLAGS:
 //w     waterlog block if previous block was water(logged) too
@@ -481,20 +478,6 @@ global_flags = 'waehubp';
 //b     set biome
 //p     only replace air
 
-
-_permutation(str) -> (
-    if(type(str) == 'string', str = split('',str));
-    if(length(str) == 0, return([]));
-    ret = {};
-    for(str,
-        ret += (e = _);
-        substr = copy(str);
-        delete(substr,_i);
-        for(_permutation(substr), ret += e + _);
-    );
-    keys(ret)
-);
-global_flags_list = map(_permutation(global_flags), '-'+_);
 
 _parse_flags(flags) ->(
    symbols = split(flags);

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -106,7 +106,6 @@ __config()->{
             'type' -> 'term',
             'suggester' -> _(args) -> (
                 typed = if(args:'flag', args:'flag', typed = '-');
-                if(typed == '-', return(map(global_flags,'-'+_)));
                 typed_list = split(typed);
                 filtered_flags = filter(global_flags,!(typed_list~_));
                 map(filtered_flags,typed+_);


### PR DESCRIPTION
Fixes #29.

This PR takes load times down literally from ~1600ms to only ~10ms (at least on my end).

It replaces the extremely expensive permutation function with a cheaper flag processing directly in the suggester (the only thing I don't really like is the `return()`, but there was already one there).

This code converts the `global_flags` to a list, so it can be used directly (it could be processed with `split()`, but it's not that bad...).

Then, in the suggester, it splits what the user typed into a list and filters the `global_flags` list to remove the flags that are already contained in the `typed` list. After that, it joins each entry in the filtered list with what the user typed.

**New**: Now it also checks that all characters in typed list exist in `global_flags`, and that there are no duplicates (by checking if the character exists in a list of what has been already checked.

## Profiling (if I didn't mess it up)

About 3500 runs per tick when not failing with longest chain, about 230 when failing in longest chain (because of the `return`). 

Longest chain = `-abhepuw` (+`j` if failing test). This is the longest because once it fails, it returns, so extra characters don't matter.

To put that into perspective, the previous suggester was a lot slower. Only 7 runs per tick with the minimum string to fail (`-1`) (it was consistent, though, it would be 6-8 runs per tick in any configuration)