### PR TITLE
Moar flags

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -83,10 +83,12 @@ an effect in each case.
 Available flags:
 
  - `-u` -> Places blocks without block updates
- - `-w` -> Waterlogs blocks placed in water or in other waterlogged blocks
+ - `-w` -> Waterlogs blocks placed in water or in other waterlogged blocks, air included
+ - `-d` -> Removes water and waterlogged state from placed blocks. Applies before `-w`
  - `-p` -> Only replaces air blocks when setting an area
  - `-e` -> Copies/moves entities from old location to new location. Technically, a new entity is generated with same data
     and position within the structure as the old one, so all that changes is UUID. Undoing will not remove these entities
  - `-b` -> Copies old biomes to new location.
  - `-a` -> Pasting a structure will not paste the air blocks within the structure.
-
+ - `-s` -> Preserves block states when seting blocks
+ - `-g` -> When replacing air or water, greenery corresponding to each medium will be replaced too

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -494,8 +494,8 @@ __on_tick() ->
 );
 
 
-__on_player_swings_hand(player, hand) ->
-//__on_player_clicks_block(player, block, face) -> 
+//__on_player_swings_hand(player, hand) ->
+__on_player_clicks_block(player, block, face) -> 
 (
     if(player~'holds':0==global_wand,
         if (global_quick_select,
@@ -1252,7 +1252,6 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
             block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','true')
         ); 
     );
-    print(block);
     if(flags~'g', 
         if(replacement:0=='water' && has(global_water_greenery,s=str(existing)), replacement=[s, null, [], false]);
         if(replacement:0=='air' && has(global_air_greenery,s=str(existing)), replacement=[s, null, [], false]);
@@ -1523,9 +1522,9 @@ expand(centre, magnitude)->(
     add_to_history('expand',player)
 );
 
-_copy(centre, force)->(
+_copy(origin, force)->(
     player = player();
-    if(!centre,centre=pos(player));
+    if(!origin,origin=pos(player));
     [pos1,pos2]=_get_current_selection(player);
     if(global_clipboard,
         if(force,
@@ -1540,8 +1539,9 @@ _copy(centre, force)->(
     global_clipboard+=if(flags~'e',entity_area('*',avg_pos,map(avg_pos-min_pos,abs(_))),[]);//always gonna have
 
     volume(pos1,pos2,
-        global_clipboard+=[centre-pos(_),block(_),biome(_)]//all the important stuff, can add flags later if we want
+        global_clipboard+=[pos(_)-origin,block(_),biome(_)]//all the important stuff, can add flags later if we want
     );
+    for(global_clipboard, if(_i>0, print([_:1, _:0])));
 
     _print(player,'copy_success',length(global_clipboard)-1,length(global_clipboard:0));
 );
@@ -1549,7 +1549,6 @@ _copy(centre, force)->(
 paste(pos, flags)->(
     player=player();
     if(!pos,pos=pos(player));
-    [pos1,pos2]=_get_current_selection(player);
     if(!global_clipboard,_error(player, 'paste_no_clipboard', player));
     flags=_parse_flags(flags);
 
@@ -1557,6 +1556,9 @@ paste(pos, flags)->(
     for(range(1,length(global_clipboard)),//cos gotta skip the entity one
         [pos_vector, old_block, old_biome]=global_clipboard:_;
         new_pos=pos+pos_vector;
+
+        print([old_block, new_pos]);
+
         if(!(flags~'a'&&air(old_block)),
             set_block(new_pos, old_block, null, flags, {'biome'->old_biome})
         )

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1223,8 +1223,8 @@ feature(pos, args, flags) -> (
 
 //Command processing functions
 
-global_water_greenery = {'seagrass'->null, 'tall_seagrass'->null, 'kelp'->null};
-global_air_greenery = {'grass'->null, 'tall_grass'->null, 'fern'->null, 'large_fern'->null};
+global_water_greenery = {'seagrass', 'tall_seagrass', 'kelp_plant'};
+global_air_greenery = {'grass', 'tall_grass', 'fern', 'large_fern'};
 
 set_block(pos, block, replacement, flags, extra)->(//use this function to set blocks
     success=null;
@@ -1247,9 +1247,11 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
         ); 
     );
     if(flags~'g', 
-        if(replacement=='water' && has(global_water_greenery,existing), replacement=existing);
-        if(replacement=='air' && has(global_air_greenery,existing), replacement=existing);
+        if(replacement:0=='water' && has(global_water_greenery,s=str(existing)), replacement=[s, null, [], false]);
+        if(replacement:0=='air' && has(global_air_greenery,s=str(existing)), replacement=[s, null, [], false]);
     );
+    if(existing!='air', print([st = str(existing), type(st)]));
+    //print([re=replacement:0, type(re)]);
 
     if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
         postblock=if(flags && flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1239,7 +1239,7 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
     );
     if(flags~'d', 
         if(
-            block=='water', block=='air',
+            block=='water', block='air',
             block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','false')
         );
     );
@@ -1248,10 +1248,11 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
         block_state(existing, 'waterlogged')=='true'
         ), 
         if(
-            block=='air', block=='water', // "waterlog" air blocks
+            block=='air', block='water', // "waterlog" air blocks
             block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','true')
         ); 
     );
+    print(block);
     if(flags~'g', 
         if(replacement:0=='water' && has(global_water_greenery,s=str(existing)), replacement=[s, null, [], false]);
         if(replacement:0=='air' && has(global_air_greenery,s=str(existing)), replacement=[s, null, [], false]);

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1250,8 +1250,6 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
         if(replacement:0=='water' && has(global_water_greenery,s=str(existing)), replacement=[s, null, [], false]);
         if(replacement:0=='air' && has(global_air_greenery,s=str(existing)), replacement=[s, null, [], false]);
     );
-    if(existing!='air', print([st = str(existing), type(st)]));
-    //print([re=replacement:0, type(re)]);
 
     if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
         postblock=if(flags && flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1230,6 +1230,9 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
     success=null;
     existing = block(pos);
 
+    // undo expects positions, not blocks
+    if(type(pos)!='list', pos=pos(pos));
+
     state = if(flags~'s',
         bs_e=block_state(existing);
         bs_b=block_state(block);
@@ -1284,7 +1287,7 @@ add_to_history(function,player)->(
         'type'->function,
         'affected_positions'->global_affected_blocks
     };
-    _print(player,'filled',length(global_affected_blocks));
+
     global_affected_blocks=[];
     global_history+=command;
 );

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1237,9 +1237,9 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
         bs_e=block_state(existing);
         bs_b=block_state(block);
         if(all(keys(bs_e), has(bs_b, _)), 
-            bs_e, if(flags,{},null)
+            bs_e, {}
         );
-    );
+    , {});
     if(flags~'d', 
         if(
             block=='water', block='air',

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1541,7 +1541,6 @@ _copy(origin, force)->(
     volume(pos1,pos2,
         global_clipboard+=[pos(_)-origin,block(_),biome(_)]//all the important stuff, can add flags later if we want
     );
-    for(global_clipboard, if(_i>0, print([_:1, _:0])));
 
     _print(player,'copy_success',length(global_clipboard)-1,length(global_clipboard:0));
 );
@@ -1556,8 +1555,6 @@ paste(pos, flags)->(
     for(range(1,length(global_clipboard)),//cos gotta skip the entity one
         [pos_vector, old_block, old_biome]=global_clipboard:_;
         new_pos=pos+pos_vector;
-
-        print([old_block, new_pos]);
 
         if(!(flags~'a'&&air(old_block)),
             set_block(new_pos, old_block, null, flags, {'biome'->old_biome})

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -494,8 +494,7 @@ __on_tick() ->
 );
 
 
-//__on_player_swings_hand(player, hand) ->
-__on_player_clicks_block(player, block, face) -> 
+__on_player_swings_hand(player, hand) ->
 (
     if(player~'holds':0==global_wand,
         if (global_quick_select,

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -653,7 +653,7 @@ _set_or_give_wand(wand) -> (
     )
 );
 
-global_flags = ['w','a','e','h','u','b','p','d'];
+global_flags = ['w','a','e','h','u','b','p','d','s'];
 
 //FLAGS:
 //w     waterlog block if previous block was water(logged) too
@@ -664,6 +664,7 @@ global_flags = ['w','a','e','h','u','b','p','d'];
 //b     set biome
 //p     only replace air
 //d     "dry" out the pasted structure (remove water and waterlogged)
+//s     keep block states of replaced block, if new block matches
 
 
 _parse_flags(flags) ->(
@@ -1225,7 +1226,7 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
     success=null;
     existing = block(pos);
 
-    state = if(flags,{},null);
+    state = if(flags~'s', block_state(replacement), if(flags,{},null));
     if(flags~'d', if(block=='water', block=='air', put(state,'waterlogged','false')));
     if(flags~'w' && (existing == 'water' && block_state(existing,'level')=='0') || block_state(existing,'waterlogged')=='true', 
         if(block=='air', block=='water', put(state,'waterlogged','true')); // "waterlog" air blocks

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -494,8 +494,8 @@ __on_tick() ->
 );
 
 
-//__on_player_swings_hand(player, hand) ->
-__on_player_clicks_block(player, block, face) -> 
+__on_player_swings_hand(player, hand) ->
+//__on_player_clicks_block(player, block, face) -> 
 (
     if(player~'holds':0==global_wand,
         if (global_quick_select,

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1286,7 +1286,8 @@ add_to_history(function,player)->(
         'type'->function,
         'affected_positions'->global_affected_blocks
     };
-
+    
+    _print(player,'filled',length(global_affected_blocks));
     global_affected_blocks=[];
     global_history+=command;
 );

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -776,7 +776,7 @@ global_default_lang=[
 
     'clear_clipboard =                wi Cleared player %s\'s clipboard',
     'copy_clipboard_not_empty =       ri Clipboard for player %s is not empty, use "/copy force" to overwrite existing clipboard data',//player
-    'copy_force =                     ri Overwriting previous clipboard selection with new one',
+    'copy_force =                     di Overwriting previous clipboard selection with new one',
     'copy_success =                   gi Successfully copied %s blocks and %s entities to clipboard',//blocks number, entity number
     'paste_no_clipboard =             ri Cannot paste, clipboard for player %s is empty',//player
 
@@ -1231,9 +1231,20 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
     existing = block(pos);
 
     state = if(flags~'s', block_state(existing), if(flags,{},null));
-    if(flags~'d', if(block=='water', block=='air', put(state,'waterlogged','false')));
-    if(flags~'w' && (existing == 'water' && block_state(existing, 'level')=='0') || block_state(existing, 'waterlogged')=='true', 
-        if(block=='air', block=='water', put(state, 'waterlogged','true')); // "waterlog" air blocks
+    if(flags~'d', 
+        if(
+            block=='water', block=='air',
+            block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','false')
+        );
+    );
+    if(flags~'w' && (
+        (existing == 'water' && block_state(existing, 'level')=='0') ||
+        block_state(existing, 'waterlogged')=='true'
+        ), 
+        if(
+            block=='air', block=='water', // "waterlog" air blocks
+            block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','true')
+        ); 
     );
     if(flags~'g', 
         if(replacement=='water' && has(global_water_greenery,existing), replacement=existing);
@@ -1267,7 +1278,6 @@ add_to_history(function,player)->(
         'type'->function,
         'affected_positions'->global_affected_blocks
     };
-    print(global_affected_blocks);
     _print(player,'filled',length(global_affected_blocks));
     global_affected_blocks=[];
     global_history+=command;
@@ -1302,7 +1312,6 @@ undo(moves)->(
 
         delete(global_history,(length(global_history)-1))
     );
-    print(global_affected_blocks);
     global_undo_history+=global_affected_blocks;//we already know that its not gonna be empty before this, so no need to check now.
     _print(player, 'success_undo', moves, length(global_affected_blocks));
     global_affected_blocks=[];

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -653,7 +653,7 @@ _set_or_give_wand(wand) -> (
     )
 );
 
-global_flags = ['w','a','e','h','u','b','p'];
+global_flags = ['w','a','e','h','u','b','p','d'];
 
 //FLAGS:
 //w     waterlog block if previous block was water(logged) too
@@ -663,6 +663,7 @@ global_flags = ['w','a','e','h','u','b','p'];
 //u     set blocks without updates
 //b     set biome
 //p     only replace air
+//d     "dry" out the pasted structure (remove water and waterlogged)
 
 
 _parse_flags(flags) ->(
@@ -1220,12 +1221,15 @@ feature(pos, args, flags) -> (
 
 //Command processing functions
 
-set_block(pos,block, replacement, flags, extra)->(//use this function to set blocks
+set_block(pos, block, replacement, flags, extra)->(//use this function to set blocks
     success=null;
     existing = block(pos);
 
     state = if(flags,{},null);
-    if(flags~'w' && existing == 'water' && block_state(existing,'level') == '0',put(state,'waterlogged','true'));
+    if(flags~'d', if(block=='water', block=='air', put(state,'waterlogged','false')));
+    if(flags~'w' && (existing == 'water' && block_state(existing,'level')=='0') || block_state(existing,'waterlogged')=='true', 
+        if(block=='air', block=='water', put(state,'waterlogged','true')); // "waterlog" air blocks
+    );
 
     if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
         postblock=if(flags && flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -494,8 +494,8 @@ __on_tick() ->
 );
 
 
-__on_player_swings_hand(player, hand) ->
-//__on_player_clicks_block(player, block, face) -> 
+//__on_player_swings_hand(player, hand) ->
+__on_player_clicks_block(player, block, face) -> 
 (
     if(player~'holds':0==global_wand,
         if (global_quick_select,
@@ -1527,7 +1527,7 @@ _copy(centre, force)->(
         global_clipboard+=[centre-pos(_),block(_),biome(_)]//all the important stuff, can add flags later if we want
     );
 
-    _print(player,'copy_success',length(global_clipboard)-1,length(global_clipboard:0))
+    _print(player,'copy_success',length(global_clipboard)-1,length(global_clipboard:0));
 );
 
 paste(pos, flags)->(
@@ -1538,7 +1538,7 @@ paste(pos, flags)->(
     flags=_parse_flags(flags);
 
     entities=global_clipboard:0;
-    for(range(1,length(global_clipboard)-1),//cos gotta skip the entity one
+    for(range(1,length(global_clipboard)),//cos gotta skip the entity one
         [pos_vector, old_block, old_biome]=global_clipboard:_;
         new_pos=pos+pos_vector;
         if(!(flags~'a'&&air(old_block)),

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1230,7 +1230,13 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
     success=null;
     existing = block(pos);
 
-    state = if(flags~'s', block_state(existing), if(flags,{},null));
+    state = if(flags~'s',
+        bs_e=block_state(existing);
+        bs_b=block_state(block);
+        if(all(keys(bs_e), has(bs_b, _)), 
+            bs_e, if(flags,{},null)
+        );
+    );
     if(flags~'d', 
         if(
             block=='water', block=='air',

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1533,7 +1533,7 @@ _copy(origin, force)->(
         if(force,
             _print(player,'copy_force');
             global_clipboard=[],
-            _error(player,'copy_clipboard_not_empty')
+            _error(player,'copy_clipboard_not_empty', player)
         )
     );
 


### PR DESCRIPTION
Adding three new flags:
`-d` to "dry" whatever is being set: removes waterlogged states and turns water into air
`-s` to "soft place" stuff: if the existing and new blocks match, the properties from one are translated into the ones of the other
`-g` to remove greenery: when relacing air or water, a set number of other blocks are removed too: grass, fern and the tall variants for air, and seagrass and kelp for water. Other stuff (like flowers and coral fans) could be added. Maybe let the suer add them with a config (file) or setting (in-game)?

Also fixed `-w` because it used to have a bunch of problems. It now converts air into water, properly detects waterlogged blocks and doesn't throw property errors when trying to waterlog stone.

`-d` is applied before `-w`, so they can be combined to do stuff like change the water level of a build or whatever you need.

This fixes #21 and fixes #23 .