### PR TITLE
Adding two small features and a few tweaks and bugfixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Contributors:
 
 ### Main contributors
-Ghoulboy, gnembon, Firigion, BisUmTo and replaceitem.
+Ghoulboy, gnembon, Firigion, BisUmTo, replaceitem, altrisi.
 
 If you have questions, these are the people to bother first of all.
 
@@ -70,6 +70,10 @@ existing code, so you know what to do right off the bat, but here is the tl;dr, 
    e     copy/move entities as well
    b     copy/move biomes as well (handled by set_block)
    a     don't paste air
+   h	 create hollow shapes
+   d     "dry" out the pasted structure (remove water and waterlogged)
+   s     keep block states of replaced block, if new block matches
+   g     when replacing air or water, some greenery gets repalced too
    ```
    Biomes are handled by the `set_block` function, but you need to input the previous biome as a map in the `extra` 
    argument: `{'biome' -> biome}`, where the variable `biome` is the biome at the position you copied from. No need to handle

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -11,6 +11,7 @@ The main contributors to this project are:
  - Firigion     (GitHub: Firigion, Discord: Firigion#7498)
  - replaceitem  (GitHub: replaceitem, Discord: replaceitem#9118)
  - BisUmTo      (GitHub: BisUmTo, Discord: BisUmTo#8383)
+ - altrisi	 (GitHub: altrisi, Discord: altrisi#9772)
 
 ## How to use
 First of all, ensure you are running fabric-carpet 1.4.22 or above, or the area selection will not work.
@@ -23,35 +24,23 @@ It will pop up a grid, and it will follow your mouse (hovering 5 blocks in midai
 Left clicking again will reselect the whole box.
 
 ### Commands:
- - `/world-edit fill <block>` -> Fills selected area with given block
- - `/world-edit fill <block> <replacement>` -> Same as above, but also replacing blocks
- - `/world-edit undo` -> Undoes last move performed by player. This can be redone with `/world-edit redo`
- - `/world-edit undo all` -> Undoes entire undo history
- - `/world-edit undo <moves>` -> Undoes specific number of moves
- - `/world-edit undo history` -> Displays entire undo history
- - `/world-edit redo` -> Redoes a move undone by the player. Also shows up in undo history
- - `/world-edit redo all` -> Redoes all undone moves
- - `/world-edit redo <moves>` -> Redoes specific number of moves
- - `/world-edit wand` -> Sets wand to held item, or if your hand is empty, gives you the wand.
- - `/world-edit wand <wand>` -> Sets wand to specified item
- - `/world-edit rotate <pos> <degrees> <axis>` -> Rotates selection `degrees` degrees about point `pos`. Axis must be `x`,
-    `y` or `z`.
- - `/world-edit stack` -> Stacks selection once in direction player is looking in
- - `/world-edit stack <stackcount>` -> Stackes selection specified number of times in direction player is looking in
- - `/world-edit stack <stackcount> <direction>` -> Stacks selection specified number of times in direction specified by
-    player
+ - `/world-edit fill <block> [replacement]` -> Fills selection with `<block>`. If `[replacement]` is given, it only fills replacing that block or block tag.
+ - `/world-edit undo [moves]` -> Undoes last move performed by player or as many as specified by `[moves]`. This can be redone with `/world-edit redo`.
+ - `/world-edit undo all` -> Undoes entire undo history. Careful!
+ - `/world-edit undo history` -> Displays entire undo history.
+ - `/world-edit redo [moves]` -> Redoes `[moves]` ammount undone by the player, or one if not specified. Also shows up in undo history.
+ - `/world-edit redo all` -> Redoes all undone moves.
+ - `/world-edit wand <wand>` -> Sets wand to held item, or if your hand is empty, gives you the wand. With optional `[wand]` argument, it sets wand to specified item
+ - `/world-edit rotate <pos> <degrees> <axis>` -> Rotates selection `degrees` degrees about point `pos`. Axis must be `x`, `y` or `z`.
+ - `/world-edit stack [stackcount] [direction]` -> Stacks selection in the direction the player is looking if not otherwise specfied. By defaults, it stacks one time.
  - `/world-edit expand <pos> <magnitude>` -> Expands selection by whatever magnitude specified by player, from pos `pos`
  - `/world-edit move <pos>` -> Moves selection to `pos`
- - `/world-edit copy` -> Copies selection to clipboard. By default, will not override the existing clipboard (can be changed
-    by adding keyword `force`), and will also take the positions relative to position of player.
- - `/world-edit copy <pos>` -> Copies selection to clipboard, with positions relative to `pos`. This is significant when 
-    pasting blocks, in terms of how it is pasted.
- - `/world-edit paste` -> Pastes selection relative to player position. Be careful incase you didnt' choose a wise spot
-    when making the selection.
- - `/world-edit paste <pos>` -> Pastes selection relative to `pos`
- - `/world-edit flood <block>` -> Performs a flood fill (fill connex volume) within the selection and starting at the player's position. Can both "fill"
- what used to be air or replace some other block.
- - `/world-edit flood <block> <axis>` -> Flood fill will happen only perpendicular to iven axis. Setting axis to `y`, for isntance, will fill the horizontal plane.
+ - `/world-edit copy [pos]` -> Copies selection to clipboard setting the origin of the structure at `[pos]`, if given, or the curren player position, if not. By default, will not override the existing clipboard (can be changed by adding keyword `force`), and will also take the positions relative to position of player.
+ - `/world-edit paste [pos]` -> Pastes selection relative to player position or to `[pos]`, if given. Be careful incase you didnt' choose a wise spot making the selection.
+ - `/world-edit flood <block>` -> Performs a flood fill (fill connex volume) within the selection and starting at the player's position. Can both "fill" used to be air or replace some other block.
+ - `/world-edit flood <block> [axis]` -> Flood fill will happen only perpendicular to iven axis. Setting axis to `y`, for isntance, will fill the horizontal plane.
+ - `/world-edit walls <block> [sides] [replacement]` -> Creates walls on the sides specified around the selection, defalts to ony vertical walls (`xz`).
+ - `/world-edit outline <block> [replacement]` -> Outlines the selection with `<block>`.
  - `/world-edit shape ...` -> Generates a shape centered arround the palyer. See brushes for all options and parameters.
 
 #### Brushes
@@ -92,3 +81,4 @@ Available flags:
  - `-a` -> Pasting a structure will not paste the air blocks within the structure.
  - `-s` -> Preserves block states when seting blocks
  - `-g` -> When replacing air or water, greenery corresponding to each medium will be replaced too
+ - `-h` -> When creating a shape, makes it hollow

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1272,7 +1272,7 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
 		);
 
 		if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
-			postblock=if(flags && flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed
+			postblock=if(flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed
 			prev_biome=biome(pos);
 			if(flag~'b'&&extra:'biome',set_biome(pos,extra:'biome'));
 			success=existing;

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -66,6 +66,10 @@ base_commands_map = [
     ['walls <block> f <flags>', _(block,flags)->walls(block,'xz',null,flags), false],
 	['walls <block> <sides> f <flags>', _(block,sides,flags)->walls(block,sides,null,flags), false],
     ['walls <block> <sides> <replacement> f <flags>', 'walls', false],
+	['outline <block>', ['outline', null, null], false],
+    ['outline <block> <replacement>', ['outline', null], [1, 'help_cmd_outline', null, null]],
+    ['outline <block> f <flags>', _(block,flags)->outline(block,null,flags), false],
+    ['outline <block> <replacement> f <flags>', 'outline', false],
 	
     ['brush clear', ['brush', 'clear', null], [-1, 'help_cmd_brush_clear', null, null]],
     ['brush list', ['brush', 'list', null], [-1, 'help_cmd_brush_list', null, null]],
@@ -749,6 +753,7 @@ global_lang_keys = global_default_lang = {
 	'help_cmd_flood_tooltip' ->   'g Use [axis] to perform flat flood in the plane perpendicular to it',
 	'help_cmd_walls' -> 		  'l Set walls of the selection',
 	'help_cmd_walls_tooltip' ->   'l Use [sides] to choose which sides to generate',
+	'help_cmd_outline' -> 		  'l Outlines the selection with <block>',
     'help_cmd_brush_clear' ->     'l Unregisters current item as brush',
     'help_cmd_brush_list' ->      'l Lists all currently regiestered brushes and their actions',
     'help_cmd_brush_info' ->      'l Gives detailed info of currently held brush',
@@ -1542,7 +1547,7 @@ expand(centre, magnitude)->(
     );
 
     for(expand_map,
-        set_block(_,expand_map:_,null,{})
+        set_block(_,expand_map:_,null,null, {})
     );
     add_to_history('expand',player)
 );
@@ -1614,4 +1619,26 @@ _walls_generic(min_corner, max_corner, sides, block, replacement, flags) -> (
 		volume(min_corner, min_corner+[ox, 0, oz], set_block(_, block, replacement, flags, {}));
 		volume(max_corner, max_corner-[ox, 0, oz], set_block(_, block, replacement, flags, {}))
 	)
+);
+
+outline(block, replafement, flags) -> (
+	player = player();
+    [pos1,pos2]=_get_current_selection(player);
+	flags=_parse_flags(flags);
+	
+	[ox, oy, oz] = pos2-pos1;
+	offsets = [ [ox, 0, 0], [0, oy, 0], [0, 0, oz] ];
+	_fill_offset(pos, offset, outer(block), outer(replacement), outer(flags))-> (
+		volume(pos, pos+offset, set_block(_, block, replacement, flags, {}))
+	);
+	
+	for(offsets,
+		_fill_offset(pos1, _);
+		_fill_offset(pos2, _*-1);
+		
+		_fill_offset(pos1+_, offsets:(_i+1));
+		_fill_offset(pos1+_, offsets:(_i+2));
+	);
+	
+    add_to_history('outline',player)	
 );

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -663,6 +663,7 @@ global_flags = ['w','a','e','h','u','b','p','d','s','g'];
 
 
 _parse_flags(flags) ->(
+	if(!flags, return({}));
    symbols = split(flags);
    if(symbols:0 != '-', return({}));
    flag_set = {};

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -60,6 +60,10 @@ base_commands_map = [
     ['flood <block> <axis>', ['flood_fill', null], [1, 'help_cmd_flood', 'help_cmd_flood_tooltip', null]],
     ['flood <block> f <flags>', _(block,flags)->flood_fill(block,null,flags), false],
     ['flood <block> <axis> f <flags>', 'flood_fill', false],
+    ['walls <block>', ['walls', null, null], false],
+    ['walls <block> <replacement>', ['walls', null], [1, 'help_cmd_walls', 'help_cmd_walls_tooltip', null]],
+    ['walls <block> f <flags>', _(block,flags)->walls(block,null,flags), false],
+    ['walls <block> <replacement> f <flags>', 'walls', false],
 
     ['brush clear', ['brush', 'clear', null], [-1, 'help_cmd_brush_clear', null, null]],
     ['brush list', ['brush', 'list', null], [-1, 'help_cmd_brush_list', null, null]],
@@ -1271,8 +1275,8 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
 			if(replacement:0=='air' && has(global_air_greenery,s=str(existing)), replacement=[s, null, [], false]);
 		);
 
-		if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
 			postblock=if(flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed
+		if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
 			prev_biome=biome(pos);
 			if(flag~'b'&&extra:'biome',set_biome(pos,extra:'biome'));
 			success=existing;
@@ -1580,3 +1584,18 @@ paste(pos, flags)->(
     add_to_history('paste',player)
 );
 
+walls(block, replacement, flags) -> (
+	player = player();
+    [pos1,pos2]=_get_current_selection(player);
+	[ox, oy, oz] = pos2-pos1;
+	flags=_parse_flags(flags);
+	
+	print(replacement);
+	
+	volume(pos1, pos1+[ox, oy, 0], set_block(_, block, replacement, flags, {}));
+	volume(pos1, pos1+[0, oy, oz], set_block(_, block, replacement, flags, {}));
+	volume(pos2, pos2-[ox, oy, 0], set_block(_, block, replacement, flags, {}));
+	volume(pos2, pos2-[0, oy, oz], set_block(_, block, replacement, flags, {}));
+	
+    add_to_history('walls',player)
+);

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -36,7 +36,7 @@ base_commands_map = [
     ['stack <count>', ['stack',null,null], false],
     ['stack <count> <direction>', ['stack',null], [0, 'help_cmd_stack', 'help_cmd_stack_tooltip', null]],
     ['stack f <flag>', _(flags)->stack(1,null,flags), false], //TODO here too Help for flags
-    ['stack <count> f <flag>', _(stackcount,flags)->stack(1,null,flags), false],
+    ['stack <count> f <flag>', _(count,flags)->stack(count,null,flags), false],
     ['stack <count> <direction> f <flag>', 'stack', false],
     ['expand <pos> <magnitude>', 'expand', [-1, 'help_cmd_expand', 'help_cmd_expand_tooltip', null]],
     ['move <pos>', ['move',null], [-1, 'help_cmd_move', null, null]],
@@ -262,7 +262,7 @@ __config()->{
         'saxis'->{'type'->'term', 'options'->['+x', '-x', '+y', '-y', '+z', '-z']},
         'wand'->{'type'->'item','suggest'->['wooden_sword','wooden_axe']},
         'direction'->{'type'->'term','options'->['north','south','east','west','up','down']},
-        'stack'->{'type'->'int','min'->1,'suggest'->[]},
+        'count'->{'type'->'int','min'->1,'suggest'->[]},
         'flag' -> {
             'type' -> 'term',
             'suggester' -> _(args) -> (
@@ -1570,3 +1570,4 @@ paste(pos, flags)->(
     );
     add_to_history('paste',player)
 );
+

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1275,13 +1275,14 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
 			if(replacement:0=='air' && has(global_air_greenery,s=str(existing)), replacement=[s, null, [], false]);
 		);
 
-			postblock=if(flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed
-		if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
-			prev_biome=biome(pos);
-			if(flag~'b'&&extra:'biome',set_biome(pos,extra:'biome'));
-			success=existing;
-			global_affected_blocks+=[pos,existing,{'biome'->prev_biome}];
-		);
+
+    if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
+        postblock=if(flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); 
+        prev_biome=biome(pos);
+        if(flag~'b'&&extra:'biome',set_biome(pos,extra:'biome'));
+        success=existing;
+        global_affected_blocks+=[pos,existing,{'biome'->prev_biome}];
+    );
 		bool(success), //cos undo uses this
 		false
 	)

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1606,9 +1606,7 @@ paste(pos, flags)->(
         [pos_vector, old_block, old_biome]=global_clipboard:_;
         new_pos=pos+pos_vector;
 
-        if(!(flags~'a'&&air(old_block)),
-            set_block(new_pos, old_block, null, flags, {'biome'->old_biome})
-        )
+    	set_block(new_pos, old_block, null, flags, {'biome'->old_biome})
     );
     add_to_history('paste',player)
 );

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1232,47 +1232,50 @@ global_water_greenery = {'seagrass', 'tall_seagrass', 'kelp_plant'};
 global_air_greenery = {'grass', 'tall_grass', 'fern', 'large_fern'};
 
 set_block(pos, block, replacement, flags, extra)->(//use this function to set blocks
-    success=null;
-    existing = block(pos);
+	if( !( flags~'a' && block=='air' ) ,
+		success=null;
+		existing = block(pos);
 
-    // undo expects positions, not blocks
-    if(type(pos)!='list', pos=pos(pos));
+		// undo expects positions, not blocks
+		if(type(pos)!='list', pos=pos(pos));
 
-    state = if(flags~'s',
-        bs_e=block_state(existing);
-        bs_b=block_state(block);
-        if(all(keys(bs_e), has(bs_b, _)),
-            bs_e, {}
-        );
-    , {});
-    if(flags~'d',
-        if(
-            block=='water', block='air',
-            block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','false')
-        );
-    );
-    if(flags~'w' && (
-        (existing == 'water' && block_state(existing, 'level')=='0') ||
-        block_state(existing, 'waterlogged')=='true'
-        ),
-        if(
-            block=='air', block='water', // "waterlog" air blocks
-            block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','true')
-        );
-    );
-    if(flags~'g',
-        if(replacement:0=='water' && has(global_water_greenery,s=str(existing)), replacement=[s, null, [], false]);
-        if(replacement:0=='air' && has(global_air_greenery,s=str(existing)), replacement=[s, null, [], false]);
-    );
+		state = if(flags~'s',
+			bs_e=block_state(existing);
+			bs_b=block_state(block);
+			if(all(keys(bs_e), has(bs_b, _)),
+				bs_e, {}
+			);
+		, {});
+		if(flags~'d',
+			if(
+				block=='water', block='air',
+				block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','false')
+			);
+		);
+		if(flags~'w' && (
+			(existing == 'water' && block_state(existing, 'level')=='0') ||
+			block_state(existing, 'waterlogged')=='true'
+			),
+			if(
+				block=='air', block='water', // "waterlog" air blocks
+				block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','true')
+			);
+		);
+		if(flags~'g',
+			if(replacement:0=='water' && has(global_water_greenery,s=str(existing)), replacement=[s, null, [], false]);
+			if(replacement:0=='air' && has(global_air_greenery,s=str(existing)), replacement=[s, null, [], false]);
+		);
 
-    if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
-        postblock=if(flags && flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed
-        prev_biome=biome(pos);
-        if(flag~'b'&&extra:'biome',set_biome(pos,extra:'biome'));
-        success=existing;
-        global_affected_blocks+=[pos,existing,{'biome'->prev_biome}];
-    );
-    bool(success)//cos undo uses this
+		if(block != existing && (!replacement || _block_matches(existing, replacement)) && (!flags~'p' || air(pos)),
+			postblock=if(flags && flags~'u',without_updates(set(existing,block,state)),set(existing,block,state)); //TODO remove "flags && " as soon as the null~'u' => 'u' bug is fixed
+			prev_biome=biome(pos);
+			if(flag~'b'&&extra:'biome',set_biome(pos,extra:'biome'));
+			success=existing;
+			global_affected_blocks+=[pos,existing,{'biome'->prev_biome}];
+		);
+		bool(success), //cos undo uses this
+		false
+	)
 );
 
 _block_matches(existing, block_predicate) ->

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -1228,11 +1228,16 @@ feature(pos, args, flags) -> (
 
 //Command processing functions
 
-global_water_greenery = {'seagrass', 'tall_seagrass', 'kelp_plant'};
+global_water_greenery = {'seagrass', 'tall_seagrass', 'kelp_plant', 'kelp'};
 global_air_greenery = {'grass', 'tall_grass', 'fern', 'large_fern'};
 
+
 set_block(pos, block, replacement, flags, extra)->(//use this function to set blocks
-	if( !( flags~'a' && block=='air' ) ,
+
+	if( !( 
+			(flags~'a' && block=='air' ) || 
+			((flags~'a' &&flags~'g') &&has(global_air_greenery, str(block))) 
+		),
 		success=null;
 		existing = block(pos);
 
@@ -1248,7 +1253,7 @@ set_block(pos, block, replacement, flags, extra)->(//use this function to set bl
 		, {});
 		if(flags~'d',
 			if(
-				block=='water', block='air',
+				block=='water' || (flags~'g' &&has(global_water_greenery, str(block))) , block='air',
 				block_state(block, 'waterlogged')!=null, put(state, 'waterlogged','false')
 			);
 		);

--- a/world-edit.sc
+++ b/world-edit.sc
@@ -73,7 +73,8 @@ base_commands_map = [
 	
     ['brush clear', ['brush', 'clear', null], [-1, 'help_cmd_brush_clear', null, null]],
     ['brush list', ['brush', 'list', null], [-1, 'help_cmd_brush_list', null, null]],
-    ['brush info', ['brush', 'info', null], [-1, 'help_cmd_brush_info', null, null]],
+    ['brush info', ['brush', 'info', null], false],
+    ['brush info <brush>', _(brush)-> brush('info', null, brush), [0, 'help_cmd_brush_info', null, null]],
     ['brush reach', ['brush', 'reach', null], false],
     ['brush reach <length>', _(length)-> brush('reach', null, length), [0, 'help_cmd_brush_reach', null, null]],
     ['brush cube <block> <size>', _(block, size_int) -> brush('cube', null, block, size_int, null), false],
@@ -300,10 +301,8 @@ __config()->{
         'length'->{'type'->'int','min'->1,'suggest'->[5, 10, 30]},
         'rotation'->{'type'->'int','suggest'->[0, 90]},
         'vertices'->{'type'->'int', 'min'->3 ,'suggest'->[3, 5, 7]},
-        'feature'->{
-            'type'->'term',
-            'options'-> get_features_list()
-        },
+        'feature'->{'type'->'term','options'-> get_features_list()},
+		'brush'->{'type'->'term', 'suggester'->_(ignered)->keys(global_brushes)},
     }
 };
 //player globals
@@ -800,21 +799,28 @@ global_lang_keys = global_default_lang = {
     'no_selection_error' ->             'r Missing selection for operation for player %s', //player
     'new_wand' ->                       'wi %s is now the app\'s wand, use it with care.', //wand item
     'invalid_wand' ->                   'r Wand has to be a tool or weapon',
-
-    'new_brush' ->                      'wi %s is now a brush with action %s',
-    'brush_info' ->                     'w %s has action %s bound to it with parameters %s and flags %s',
+	
+	'brush_item_tooltip' ->				'^g Click to get one!',
+    'brush_info_title' ->               'y Brush registered to ',
+	'brush_info_action' ->				'b \ Action: ',
+	'brush_info_params' ->				'b \ Parameters: ',
+	'brush_info_params_tooltip' ->		'^g See help to understand what each parameter is',
+	'brush_info_flags' ->				'b \ Flags: ',
+	'brush_info_no_flags' ->			'w no flags',
     'brush_replaced' ->                 'w Replacing previous action for brush in %s',
+	'brush_new' ->						'w Registerd new %s brush to %s', //item, action
     'brush_list_header' ->              'bc === Current brushes are ===',
     'brush_empty_list' ->               'gi No brushes registerd so far',
-    'brush_extra_info' ->               'ig For detailed info on a brush use /world-edit brush info',
+    'brush_extra_info' ->               'ig For detailed info on a brush click the [i] icon',
     'brush_new_reach' ->                'w Brush reach was set to %d blocks',
     'brush_reach' ->                    'w Brush reach is currently %d blocks',
+	'no_brush_error'->					'r %s in not a brush', //item
 };
 task(_()->write_file('langs/en_us','json',global_default_lang)); // Make a template for translators. Async cause why not. Maybe make an async section at the bottom?
 
 
 _get_lang_list() -> (
-  filter(map(list_files('langs','json'), slice(_,6)), !(_~' ')); // Any JSON files in /langs/ that don't have spaces
+  filter(map(list_files('langs','json'), slice(_,6)), !(_~' ')); // Any JSON files in /langs/ that doesn't have spaces
 );
 
 _change_lang(lang)->(
@@ -897,14 +903,26 @@ brush(action, flags, ...args) -> (
         if(global_brushes,
             _print(player, 'brush_list_header');
             for(pairs(global_brushes),
-                print(player, str('%s: %s', _:0, _:1:0));
+                print(player, format(
+					str('lb \ %s: ', item=_:0),
+					_translate('brush_item_tooltip'), 
+					str('!/give %s %s',player, held_item),
+					str('w %s ', _:1:0),
+					'db [i]',
+					str('^g Click for more info on %s brush', item),
+					str('!/world-edit brush info %s', item)
+				));
             );
             _print(player, 'brush_extra_info'),
             _print(player, 'brush_empty_list')
         ),
         action=='info', //TODO improve info with better descriptions
+		if(args, held_item=args:0);
         if(has(global_brushes, held_item),
-            _print(player, 'brush_info', held_item, params=global_brushes:held_item:0, params:1, params:2),
+            print(player, format( _translate('brush_info_title'), str('bl %s', held_item), _translate('brush_item_tooltip'), str('!/give %s %s',player, held_item) ));
+			print(player, format( _translate('brush_info_action'), str('w %s', (params=global_brushes:held_item):0) ));
+			print(player, format( _translate('brush_info_params'), str('w %s%s','',params:1), _translate('brush_info_params_tooltip') ));
+			print(player, format( _translate('brush_info_flags'), if(params:2, str('w %s', params:2), _translate('brush_info_no_flags') ) )),
             _error(player, 'no_brush_error', held_item)
         ),
         action=='reach',
@@ -918,10 +936,12 @@ brush(action, flags, ...args) -> (
             _print(player, 'brush_replaced', held_item)
         );
         global_brushes:held_item = [action, args, flags];
+		_print(player, 'brush_new', action, held_item);
 
         if(action=='feature', print(player, format('d Beware, placing features is very experimental and doesn\'t have support for the undo function')))
     )
 );
+
 
 _brush_action(pos, brush) -> (
     [action, args, flags] = global_brushes:brush;


### PR DESCRIPTION
Maybe it's bad practice, but I went ahead and fixed some bugs, added two small features and improved some stuff:

- Fixed an unreported bug in `stack` where it would not properly use `count`; registered `count` as a variable, since it was still named `stack`
- Fixed #39 by just returning null inside `_parse_flags()` if flags null to begin with
- Adjusted behavior of `-a` so any function that makes sense can use it (stack, rotate, move, etc) by adding the check to `set_block()`. Now players can also use it for some obscure stuff like a random mask when replacing stuff using palettes
- Adjusted behavior of `-g` to work with `-d` and `-a` (also possible due to `-a` being moved into `set_block()`)
- Added `outline` and `wall` commands, were missing ports form the standard world edit
- Improved `brush list` and `brush info` as per #28: they now have colour, a proper list structure, a clickable menu for more info and to get the brush, and a reasonable formatting and grammar
- Probably also some minor things like typos and old comments
- Updated docu and CONTRIBUTE.md with missing info