### PR TITLE
Added angel block and framework to handle new items with actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,11 @@ existing code, so you know what to do right off the bat, but here is the tl;dr, 
    e     copy/move entities as well
    b     copy/move biomes as well (handled by set_block)
    a     don't paste air
-   h	 create hollow shapes
+   h	   create hollow shapes
    d     "dry" out the pasted structure (remove water and waterlogged)
    s     keep block states of replaced block, if new block matches
    g     when replacing air or water, some greenery gets repalced too
+   l     when registering a brush with this flag, the brush will trace for liquids as well as blocks
    ```
    Biomes are handled by the `set_block` function, but you need to input the previous biome as a map in the `extra` 
    argument: `{'biome' -> biome}`, where the variable `biome` is the biome at the position you copied from. No need to 
@@ -122,18 +123,18 @@ add your commands into the `base_command_map` instead with the following format:
 -  `[command_for_carpet, interpretation_for_carpet, false] (will hide it from help menu)`
 -  `[command_for_carpet, interpretation_for_carpet, [optional_arguments_since, description, description_tooltip, description_action]]`
 
-Explained in words: In the list, you add the command for carpet ("syntax") (eg `'fill <block>'`) as the first element.
-The second element is the "interpretation" for Carpet (what will that do, basically the other side of a regular commands
-map), and then the third item is either `false` (to prevent it from appearing in help menu, for example, `help` can be 
-hidden since `help [page]` is basically the same) or another list with the info for the help menu, which you can find below.
+In words: the first two arguments are the usual key and value arguments in the `__config():'commands'` map when defining custom commands 
+with scarpet the regular way. For example, they can be `'fill <block>'` and `'fill_with_blocks'`, where the latter is a user-defined 
+function. The third element in the list is what defines the representation of the command in the help menu. Use `false` to hide the command
+from the help menu (not every variation of a command needs it's individual entry), or see below for more info.
 
-- `command_for_carpet`: As mentioned, it is the command "syntax" that will be passed to Carpet, the equivalent to the 
-  first side of a regular commands map
-- `interpretation_for_carpet`: As mentioned, it is how Carpet will process that command, the equivalent to the other side
-  of a regular commands map
-- `optional_arguments_since`: The position of the first argument to make visibly optional (`<arg>` to `[arg]`). Can be 
-  used to merge multiple commands in help menu (e.g. `help` and `help <page>` into `help [page]`). If the command shouldn't
-  have any optional arguments, use `-1`
+- `command_for_carpet`: it's the command "syntax" that will be passed to Carpet, the equivalent to the 
+  key in regular commands map
+- `interpretation_for_carpet`: it's how Carpet will process that command, the equivalent to value argument of a regular commands map
+- `optional_arguments_since`: the index of the first optional argument in the command out of all arguments given. optional arguemtns will
+  be printed as `[arg]`, and mandaroty ones as `<arg>` For isntance, setting it to `0` will make all arguments optional, while setting it to
+  `2` means the first two arguments are mandatory. Set it to `-1` if all arguments are mandatory. This can be used to merge multiple commands
+  into one help entry (for isntance, `help [page]` represents both the `help` and `help <page>` commands).
 - `description`: The description of the command in the help menu. Must be a translation string (see [Messages](#messages))
   or a lambda (if you need arguments in the translation, `_()->_translate('string', ...args)`). (it can technically be 
   `null`, but the idea is to add a description)
@@ -141,12 +142,48 @@ hidden since `help [page]` is basically the same) or another list with the info 
   it must be a translation string or a lambda (if you need arguments in the translation)
 - `description_action` An optional action to run when the player clicks the description. Can be `null`. If present, it must
   start with either `!` (to specify it will _run_ the action) or `?` (to specify it will _suggest_ the action). The command
-  is automatically prefixed with `/worldedit ` (and a space)
+  is automatically prefixed with `/world-edit ` (and a space)
 
 The command suggestion will be derived from `command_for_carpet`: everything before the first `<`.
 
 You should try to fit each entry in a single line (when viewed in the help menu) for proper pagination (until something 
 is done).
+
+#### Items with new functionality
+
+Some items have built-in functionality, like the wand, but the user has the ability to add more items with actions associated
+with them (like brushes and angel block, for instance). If you want to add a new item functionality (say, building wand, for 
+example), then you need to take care of a few things, to avoid one item having many actions associated with it:
+  * When registering an item for a new action, call `new_action_item(item, action)`. This will check if the item is already 
+  registered for another action and call `_error()` if it is. Remember, that `exit`s, so there no need for an extra, that function 
+  does the check for you.
+  * When unregistering an item (not replacing it with a new one, like the wand does, actualy deleting it), call 
+  `remove_action_item(item, action)`, which will check that the requested item indeed has that action registered to it. It also 
+  `exit`s if it fails. For isntance, `brush` uses it like this:
+  ```C++
+      if(
+        action=='clear',
+        remove_action_item(held_item, 'brush'); // delete old item from global_items_with_actions
+        delete(global_brushes, held_item); // deregister item as brush
+        ...
+  ```
+  * For these two functions to work properly, you any new action you add needs a few things: 
+      1. add your action's name to the `global_lang_keys` so it can be translated
+      2. add your action's code name to `global_item_action_translation_key` so it can be requested from `global_lang_keys` (for example,
+      the angel block's code name is `'angel'`, with a translation key `'action_item_angel'`, which gives the text `'angel block item'`)
+      3. if your new action has a default tool or item (like the wand does), add it to `global_items_with_actions` along with it's action
+  * If registering a new item to your action just replaces the previous one, rather than adding a brand new one (think wand vs brush: one 
+  replaces the old wand with a new one, while the other adds a new brush, leaving the old one suntouched), take good care to manually 
+  delete the old item from `global_items_with_actions` just before adding the new one. Angel block for example does it like this:
+  ```C++
+  _set_angel_block_item() -> (
+    new_action_item(item = player()~'holds':0, 'angel'); // add new item
+    delete(global_items_with_actions, global_angel_block); // delete old one
+    global_angel_block = item; // register new item as angel block
+    ...
+  ```
+  This is extremely important so that old deregistered items can be reused for new actions by the player.
+
 
 #### Other functions
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -68,6 +68,7 @@ Left clicking again will reselect the whole box.
  - `/world-edit walls <block> [sides] [replacement]` -> Creates walls on the sides specified around the selection, defalts to ony vertical walls (`xz`).
  - `/world-edit outline <block> [replacement]` -> Outlines the selection with `<block>`.
  - `/world-edit shape ...` -> Generates a shape centered arround the palyer. See brushes for all options and parameters.
+ - `/world-edit angel [new|clear]` -> Angel block: click in mid air to place a (stone) block you can the build off. Without arguments, it gives the player the item registered as angel block. With `new`, it will register the currently held item as angel block item. With `clear` clears the current angel block item; you will have to register a new one to use it.
 
 #### Brushes
 


### PR DESCRIPTION
This is built on the drain branch, because it modifies some of the same parts of the code that feature doe,s and it would have been a pain to merge them separately to master. If i should do this some other way, tell be and I'll make another PR.

It adds a single command (tree), namely `/world-edit angel [new|clear]`. Called with `new`, it will register the held item as the angel block tool. Holding it will highlight the targeted (air) block, and clicking with it will place a stone block in mid air. Calling it with `clear` will deregister the current angel block tool, and calling it without arguments will give the player the current angel block tool item.

Writing this code was a bit of a foreshadowing for how much of a pain it will be to add new commands that add arbitrary functionality to items (like currently brushes, wand and now angel block tool). Since stuff like building wands and tools from pixel sniper are listed as stuff that is gonna be added at some point, I thought it would be a good idea to write some code to wrap the addition of new items with actions. Before doing this, stuff like registering a new brush had to manually check if the item was not already a wand or an angel block tool, and angel block had to check for wand and brush, and so on.

To avoid needing to edit all existing commands when creating a new action associated to an item, there's now a global map of items with the actions associated to them. The contributor should use `new_action_item` when adding a new item, which will handle the checks for them. The actions in the map are only used in the error messages, to tell the user what's that item currently doing, if it's doing something. Since now adding something new that registers items to do stuff is a bit more involved, I updated `CONTRIBUTING.md` with the detailed instructions of what people need to do in order to add such a thing. Here's a dirty little video showing how the error messages are handled (and also how the angel block works): https://youtu.be/sKWqZOIE7sA

I also fixed an unreported bug with the `wand` command.